### PR TITLE
feat!: adopt mod-utils v6 (mod-leaflet v3)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@
     source = 'static'
     target = 'static'
   [[module.imports]]
-    path = "github.com/gethinode/mod-utils/v5"
+    path = "github.com/gethinode/mod-utils/v6"
 
 [params.modules.leaflet]
   integration = "optional"

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -5,7 +5,7 @@ title = 'Test site for mod-leaflet'
 [module]
   workspace = "mod-leaflet.work"
   [[module.imports]]
-    path = "github.com/gethinode/mod-leaflet/v2"
+    path = "github.com/gethinode/mod-leaflet/v3"
   [[module.imports.mounts]]
     source = "data"
     target = "data"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/gethinode/mod-leaflet/v2
+module github.com/gethinode/mod-leaflet/v3
 
 go 1.19
 
-require github.com/gethinode/mod-utils/v5 v5.19.0 // indirect
+require github.com/gethinode/mod-utils/v6 v6.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,3 +10,5 @@ github.com/gethinode/mod-utils/v5 v5.0.0 h1:iF8FtgzQu9BW7R94sJ77gltSZO2QkAv60EMN
 github.com/gethinode/mod-utils/v5 v5.0.0/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
 github.com/gethinode/mod-utils/v5 v5.19.0 h1:fX3gTsYoimUNqD/KeBsyBrrJ2DygQ0M7Rc8gL1HT5Tc=
 github.com/gethinode/mod-utils/v5 v5.19.0/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
+github.com/gethinode/mod-utils/v6 v6.0.1 h1:EnmMHjqnI/xyHPXFj1SdRLfVxNunJcKLGVtSAAFTQ8w=
+github.com/gethinode/mod-utils/v6 v6.0.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=

--- a/layouts/shortcodes/map.html
+++ b/layouts/shortcodes/map.html
@@ -7,17 +7,18 @@
 {{ $error := false }}
 
 {{/* Validate and initialize arguments */}}
-{{ $args := partial "utilities/InitArgs.html" (dict "structure" "map" "args" .Params "named" .IsNamedParams "group" "shortcode") }}
-{{ if or $args.err $args.warnmsg }}
-    {{ partial (cond $args.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict 
-        "partial"  "shortcodes/map.html" 
+{{ $result := partial "utilities/Args.html" (dict "structure" "map" "args" .Params "named" .IsNamedParams "group" "shortcode" "strict" false) }}
+{{ $args := $result.args }}
+{{ if or $result.err $result.warnmsg }}
+    {{ partial (cond $result.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict
+        "partial"  "shortcodes/map.html"
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
-        "details"  ($args.errmsg | append $args.warnmsg)
+        "details"  ($result.errmsg | append $result.warnmsg)
         "file"     page.File
         "position" .Position
     )}}
-    {{ $error = $args.err }}
+    {{ $error = $result.err }}
 {{ end }}
 
 {{/* Initialize local arguments */}}


### PR DESCRIPTION
## Summary

- Bump the module's own Go path from `/v2` to `/v3` and require
  `github.com/gethinode/mod-utils/v6 v6.0.1` (never v6.0.0, which carries a known camelKey
  defect).
- Migrate the module's sole `InitArgs.html` call site to the clean `Args.html` API.
- Update `config.toml` and `exampleSite/hugo.toml` module import paths and re-vendor.

Part of the mod-utils v6 adoption program: gethinode/mod-utils#334. See the mod-utils README
"Argument validation" section for the v5-to-v6 migration notes (separated envelope,
`defaulted` list, warnings-first rollout for the `InitArgs.html`/`InitTypes.html` shims).

## Migrated call sites

- `layouts/shortcodes/map.html` — the only `InitArgs.html` call site in the module. Switched to
  `partial "utilities/Args.html" (dict "structure" "map" "args" .Params "named" .IsNamedParams
  "group" "shortcode" "strict" false)`. `strict: false` because this is a user-facing shortcode
  (site-authored content). Access is via the separated `$result.args` envelope; `$error` is now
  set from `$result.err`. No dual kebab/camel handling, `_default` plumbing, or `or`-based
  falsy-fallback workarounds were present to remove — the one existing `| default` fallback
  (`$args.id | default (printf "leaflet-map-%d" .Ordinal)`) is a computed ID default that has no
  static default in the schema, so it is not the "explicit false/0 gets swallowed" hazard the
  program's standing checklist item targets and was left as-is.

## Verification (recipe step 5)

- `hugo mod graph -s exampleSite` (workspace-file exampleSite, per this module's wiring): shows
  `github.com/gethinode/mod-leaflet/v3 github.com/gethinode/mod-utils/v6@v6.0.1+vendor` only —
  no `mod-utils/v5` anywhere in the graph.
- `pnpm test` (`pnpm build` → clean, vendor, `hugo --gc --minify -s exampleSite`) exits 0. Zero
  ERROR lines. The only WARN lines are pre-existing Hugo deprecations unrelated to this module
  (`languageCode`, `.Site.Data`) — zero warnings attributable to the `map` shortcode.
- The exampleSite's existing content (`exampleSite/content/_index.md`) already exercises the
  `map` shortcode with real arguments (`class`, `lat`, `long`, `popup`, `popup-lat`,
  `popup-long`, plus the `zoom`/`id` defaults) — not a placeholder, so no demo-content seeding
  was needed for the exercise gate.
- HTML-source diff (recipe pilot refinement 5): captured `exampleSite/public/index.html` before
  and after the migration (via `git stash`/`pop` around a clean rebuild) — byte-identical.
- Visual regression (own exampleSite, `tests/visual/visual.mjs` from the Hinode program
  workspace): baseline shot from the pristine clone before any change, candidate shot after.
  `compare` result: 3 pages compared, **0 flagged**, 0.0000% diff ratio on every page
  (`categories`, `index`, `tags`). Map tile areas are masked by the harness by design (external
  tiles, non-localhost requests blocked) — the byte-identical HTML diff covers that gap.

## Evidence

- New path: `github.com/gethinode/mod-leaflet/v3`
- `hugo mod graph` v6-only line: `github.com/gethinode/mod-leaflet/v3 github.com/gethinode/mod-utils/v6@v6.0.1+vendor`
- Build exit code: 0 (zero ERROR lines)
- Migrated call sites: `layouts/shortcodes/map.html` (1 of 1)
- Warning triage: no warnings attributable to the module; 2 pre-existing unrelated Hugo
  deprecation warnings observed and left untouched (out of scope)
- Visual diff triage: 0 flagged / 3 pages, 0.0000% diff — no re-baseline needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
