### PR TITLE
feat(map): adopt cooperative gestures to stop trapping page scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@
 
 Hinode is a clean blog theme for [Hugo][hugo], an open-source static site generator. Hinode is available as a [template][repository_template], and a [main theme][repository]. This repository maintains a Hugo module to add [Leaflet][leaflet] to a Hinode site. Visit the Hinode documentation site for [installation instructions][hinode_docs].
 
+## Gestures
+
+The map uses **cooperative gestures**, so scrolling the page never gets trapped by a map in its path. It only claims a gesture that is unambiguously meant for it:
+
+| Gesture | Result |
+| --- | --- |
+| Wheel | Scrolls the page |
+| `Ctrl`/`⌘` + wheel | Zooms the map |
+| Mouse drag | Pans the map |
+| One finger | Scrolls the page |
+| Two fingers | Pans and pinch-zooms the map |
+
+A gesture the map ignores briefly shows an overlay explaining how to address the map instead. Its wording comes from the `mapZoomHint` and `mapDragHint` translations, which a site can override.
+
 ## Contributing
 
 This module uses [semantic-release][semantic-release] to automate the release of new versions. The package uses `husky` and `commitlint` to ensure commit messages adhere to the [Conventional Commits][conventionalcommits] specification. You can run `npx git-cz` from the terminal to help prepare the commit message.

--- a/assets/js/modules/leaflet/leaflet-map.js
+++ b/assets/js/modules/leaflet/leaflet-map.js
@@ -1,6 +1,77 @@
 const attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 const tile = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
 
+// How long a gesture hint stays on screen after the gesture that triggered it.
+const hintTimeout = 2000
+
+// Apple keyboards zoom with the command key, everything else with control.
+const modifier = /mac|iphone|ipad|ipod/i.test(navigator.userAgentData?.platform || navigator.platform || '')
+  ? '⌘'
+  : 'Ctrl'
+
+// Overlay explaining why the map ignored the gesture. It is advisory only, so it stays
+// hidden from assistive technology: a keyboard user reaches the zoom buttons instead and
+// never triggers it.
+function createHint (container) {
+  const hint = document.createElement('div')
+  hint.className = 'leaflet-gesture-hint'
+  hint.setAttribute('aria-hidden', 'true')
+  container.appendChild(hint)
+
+  let timer = null
+  return {
+    show (message) {
+      hint.textContent = message
+      hint.classList.add('leaflet-gesture-hint-visible')
+      clearTimeout(timer)
+      timer = setTimeout(() => hint.classList.remove('leaflet-gesture-hint-visible'), hintTimeout)
+    },
+    hide () {
+      clearTimeout(timer)
+      hint.classList.remove('leaflet-gesture-hint-visible')
+    }
+  }
+}
+
+// Cooperative gestures: the map only claims a gesture that is unambiguously meant for it, so
+// scrolling the page past the map is never trapped. A plain wheel and a single finger belong
+// to the page; Ctrl/Cmd + wheel zooms, and two fingers pan and pinch-zoom.
+//
+// Every listener runs in the capture phase, which is what makes this work: Leaflet binds its
+// own handlers deeper in the tree, so stopping the event here — or withdrawing the handler
+// here — settles the gesture before Leaflet ever sees it.
+function bindGestures (map, container, messages) {
+  const hint = createHint(container)
+
+  container.addEventListener('wheel', (e) => {
+    if (e.ctrlKey || e.metaKey) {
+      hint.hide()
+      return
+    }
+    e.stopPropagation()
+    hint.show(messages.zoom)
+  }, { capture: true, passive: true })
+
+  // Dragging stays enabled for the mouse and is withdrawn only for the duration of a
+  // one-finger touch, which is a page scroll rather than a pan.
+  container.addEventListener('touchstart', (e) => {
+    if (e.touches.length > 1) {
+      hint.hide()
+      map.dragging.enable()
+    } else {
+      map.dragging.disable()
+    }
+  }, { capture: true, passive: true })
+
+  container.addEventListener('touchmove', (e) => {
+    if (e.touches.length < 2) hint.show(messages.drag)
+  }, { capture: true, passive: true })
+
+  container.addEventListener('touchend', (e) => {
+    if (e.touches.length === 0) map.dragging.enable()
+  }, { capture: true, passive: true })
+}
+
 document.querySelectorAll('div.leaflet-map').forEach(map => {
   const viewLat = map.getAttribute('data-leaflet-view-lat')
   const viewLong = map.getAttribute('data-leaflet-view-long')
@@ -20,6 +91,17 @@ document.querySelectorAll('div.leaflet-map').forEach(map => {
       L.marker([popupLat, popupLong]).addTo(bind)
         .bindPopup(popup)
         .openPopup()
+    }
+
+    // The shortcode renders the hints so they stay translatable. Only the modifier is
+    // resolved here, because it depends on the visitor's platform.
+    const zoomHint = map.getAttribute('data-leaflet-hint-zoom')
+    const dragHint = map.getAttribute('data-leaflet-hint-drag')
+    if (zoomHint !== null && dragHint !== null) {
+      bindGestures(bind, map, {
+        zoom: zoomHint.replace('{modifier}', modifier),
+        drag: dragHint
+      })
     }
   }
 })

--- a/assets/scss/leaflet.scss
+++ b/assets/scss/leaflet.scss
@@ -1,0 +1,41 @@
+// Leaflet's own stylesheet, vendored by the postinstall script and mounted alongside this
+// file. Importing it here keeps a single "leaflet" stylesheet for the module while leaving
+// the vendored file untouched.
+@import "leaflet-vendor";
+
+// Overlay shown when a gesture was meant for the page rather than the map: a plain wheel,
+// or a single finger. It explains how to address the map instead, so an ignored gesture
+// does not read as a broken map.
+.leaflet-gesture-hint {
+    position: absolute;
+    inset: 0;
+    z-index: 999; // above the tile and marker panes, below the Leaflet controls (1000+)
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+
+    color: #fff;
+    background-color: rgb(0 0 0 / 60%);
+    text-align: center;
+    font-size: 1rem;
+
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
+
+    // The overlay is advisory. Never let it swallow the gesture it is explaining.
+    pointer-events: none;
+}
+
+.leaflet-gesture-hint-visible {
+    opacity: 1;
+    visibility: visible;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .leaflet-gesture-hint {
+        transition: none;
+    }
+}

--- a/config.toml
+++ b/config.toml
@@ -7,10 +7,11 @@
     source = "dist"
     target = "assets/js/modules/leaflet"
     includeFiles = "leaflet.js"
+  # Leaflet's own stylesheet, vendored by the postinstall script. It is mounted beside
+  # assets/scss/leaflet.scss, which imports it and adds the module's own styles.
   [[module.mounts]]
-    source = "dist"
-    target = "assets/scss"
-    includeFiles = "leaflet.scss"
+    source = "dist/leaflet.scss"
+    target = "assets/scss/leaflet-vendor.scss"
   [[module.mounts]]
     source = "dist/images"
     target = "static/css/images"
@@ -24,6 +25,9 @@
   [[module.mounts]]
     source = 'data'
     target = 'data'
+  [[module.mounts]]
+    source = 'i18n'
+    target = 'i18n'
   [[module.mounts]]
     source = 'static'
     target = 'static'

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -1,0 +1,4 @@
+- id: mapZoomHint
+  translation: "Verwenden Sie {{ . }} + Scrollen, um die Karte zu zoomen"
+- id: mapDragHint
+  translation: "Verwenden Sie zwei Finger, um die Karte zu bewegen"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,4 @@
+- id: mapZoomHint
+  translation: "Use {{ . }} + scroll to zoom the map"
+- id: mapDragHint
+  translation: "Use two fingers to move the map"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,0 +1,4 @@
+- id: mapZoomHint
+  translation: "Utilisez {{ . }} + défilement pour zoomer sur la carte"
+- id: mapDragHint
+  translation: "Utilisez deux doigts pour déplacer la carte"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -1,0 +1,4 @@
+- id: mapZoomHint
+  translation: "Gebruik {{ . }} + scrollen om in te zoomen op de kaart"
+- id: mapDragHint
+  translation: "Gebruik twee vingers om de kaart te verplaatsen"

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -1,0 +1,4 @@
+- id: mapZoomHint
+  translation: "Użyj {{ . }} + przewijanie, aby przybliżyć mapę"
+- id: mapDragHint
+  translation: "Użyj dwóch palców, aby przesunąć mapę"

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -1,0 +1,4 @@
+- id: mapZoomHint
+  translation: "Use {{ . }} + rolagem para ampliar o mapa"
+- id: mapDragHint
+  translation: "Use dois dedos para mover o mapa"

--- a/i18n/zh-hans.yaml
+++ b/i18n/zh-hans.yaml
@@ -1,0 +1,4 @@
+- id: mapZoomHint
+  translation: "按住 {{ . }} 并滚动以缩放地图"
+- id: mapDragHint
+  translation: "使用双指移动地图"

--- a/i18n/zh-hant.yaml
+++ b/i18n/zh-hant.yaml
@@ -1,0 +1,4 @@
+- id: mapZoomHint
+  translation: "按住 {{ . }} 並捲動以縮放地圖"
+- id: mapDragHint
+  translation: "使用雙指移動地圖"

--- a/layouts/shortcodes/map.html
+++ b/layouts/shortcodes/map.html
@@ -26,7 +26,11 @@
 
 {{/* Main code */}}
 {{- if not $error -}}
+    {{/* The gesture hints are rendered here so they stay translatable. The modifier is left as
+         a placeholder for the script, which resolves it to the visitor's platform. */}}
     <div id="{{ $id }}" class="leaflet-map {{ $args.class }}"
+        data-leaflet-hint-zoom="{{ T "mapZoomHint" "{modifier}" }}"
+        data-leaflet-hint-drag="{{ T "mapDragHint" }}"
         {{ with $args.lat }}data-leaflet-view-lat="{{ . }}"{{ end }}
         {{ with $args.long }}data-leaflet-view-long="{{ . }}"{{ end }}
         {{ with $args.zoom }}data-leaflet-view-zoom="{{ . }}"{{ end }}


### PR DESCRIPTION
## Problem

Leaflet binds the **wheel** to zoom and a **single finger** to pan. Scrolling the page with the
pointer over a map therefore gets swallowed and the page sticks — the classic embedded-map scroll
trap. It reproduces today on
[gethinode.com/docs/components/map](https://gethinode.com/docs/components/map/): a plain wheel over
the map takes the tiles from zoom 13 to 12 instead of scrolling the page.

This is the same trap gethinode/mod-mermaid#338 removed from inline diagrams in v4.10.0. That PR
described its goal as following *"the cooperative-gesture pattern used by embedded maps"* — so this
restores the pattern to the map it was named after.

## Change

The map now claims only a gesture that is unambiguously meant for it:

| Gesture | Before | After |
| --- | --- | --- |
| Wheel over map | zooms map (page sticks) | **page scrolls**, hint appears |
| `Ctrl`/`⌘` + wheel | page zooms | **map zooms** |
| Mouse drag | pans map | pans map (unchanged) |
| One finger | pans map (page sticks) | **page scrolls**, hint appears |
| Two fingers | — | **pans / pinch-zooms map** |
| `+`/`−`, keyboard | zooms | unchanged |

A gesture the map ignores briefly shows an overlay — *"Use ⌘ + scroll to zoom the map"* — so an
ignored gesture does not read as a broken map.

### How it works

Every listener runs in the **capture phase**. Leaflet binds its own handlers deeper in the tree, so
stopping the event here (wheel without a modifier) or withdrawing the handler here (`dragging`
during a one-finger touch) settles the gesture before Leaflet ever sees it. With the modifier held
the event is simply let through, so Leaflet applies its own tuned zoom rather than a reimplementation
of it.

### Notable details

- **The hint stays translatable.** The shortcode renders it into `data-leaflet-hint-*`; only the
  modifier is resolved in the browser, since it depends on the visitor's platform (`⌘` vs `Ctrl`).
  Adds `i18n/` for the eight languages Hinode ships, and the `i18n` mount, which the module lacked.
- **The stylesheet slot.** `dist/leaflet.scss` is Leaflet's vendored CSS, regenerated by
  `postinstall`, and it occupied the module's single `assets/scss/leaflet.scss` slot — so the overlay
  styles had nowhere to live. It is remounted as `leaflet-vendor.scss`, and a hand-written
  `assets/scss/leaflet.scss` imports it and adds the overlay. The vendored file stays untouched.
- The overlay class keeps the `leaflet-` prefix that Hinode's PurgeCSS safelist (`/^leaflet-/`)
  already covers, and is `pointer-events: none` + `aria-hidden` — it is advisory and must never
  swallow the gesture it is explaining.
- No new shortcode argument: cooperative behaviour is always on. An opt-out would just be a way to
  reintroduce the bug.

## Verification

Driven in a real browser against the block reference, with the module replaced locally into a
Hinode host:

| Check | Result |
| --- | --- |
| Plain wheel over map | tiles stay at **z13**, hint shown ✅ |
| `Ctrl` + wheel | tiles go to **z12** ✅ |
| `{modifier}` placeholder | resolved to `⌘` on macOS ✅ |
| Overlay styles compiled | `position: absolute`, scrim, `pointer-events: none` ✅ |
| Vendored Leaflet CSS still applied | container styled, 28 tiles loaded ✅ |

`pnpm test` passes.

## Review notes

The seven non-English translations are mine and **have not been reviewed by a native speaker** —
worth a look, particularly `zh-hans`/`zh-hant`. The hint timing (2s) and the dark scrim are easy to
adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)