### PR TITLE
build(deps): add Dependabot cooldown to clear the pnpm age gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,10 @@ updates:
     commit-message:
       prefix: fix
       include: scope
+    # Must stay strictly greater than .npmrc#minimum-release-age (1440 min = 1 day).
+    # Cooldown is day-granular, so 2 is the smallest value that clears the gate;
+    # below it pnpm fails CI with ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION.
+    cooldown:
+      default-days: 2
+      exclude:
+        - "@gethinode/*" # mirrors pnpm-workspace.yaml#minimumReleaseAgeExclude


### PR DESCRIPTION
## Problem

Since the pnpm migration, `.npmrc` sets `minimum-release-age=1440` (24h). pnpm enforces this **against lockfile entries at install time**, not only at resolution. Dependabot writes the new version into the lockfile without honoring `.npmrc`, so any Dependabot PR for a package published less than 24h ago fails CI on `pnpm install --frozen-lockfile`:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  semantic-release@25.0.7 was published at 2026-07-13T05:23:55.000Z,
  within the minimumReleaseAge cutoff (2026-07-12T11:43:23.903Z)
```

It fails on every OS/Node combination and blocks auto-merge. Live examples: gethinode/mod-utils#341, gethinode/mod-blocks#153.

## Fix

Mirror the install policy in the Dependabot policy via `cooldown`, rather than weakening either side.

**The invariant: Dependabot's cooldown must be strictly greater than pnpm's `minimum-release-age`.** Cooldown is day-granular and 1440 minutes is exactly 1 day, so `default-days: 2` is the smallest safe value.

Mirrors this repo's install policy: `.npmrc#minimum-release-age=1440` and `pnpm-workspace.yaml#minimumReleaseAgeExclude`.

Config validated against the official [Dependabot JSON schema](https://json.schemastore.org/dependabot-2.0.json).

## Notes

- Uses the `build` type deliberately, so semantic-release does not cut a release for a CI-config-only change.
- Dependabot **security** updates ignore `cooldown` by design; those can still trip the gate and self-heal on re-run after 24h.

Part of an org-wide sweep (25 repos). Reference: gethinode/hinode#2009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)