### PR TITLE
fix(shortcodes): give the map id the UniqueID helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gethinode/mod-leaflet/v3
 
 go 1.19
 
-require github.com/gethinode/mod-utils/v6 v6.0.1 // indirect
+require github.com/gethinode/mod-utils/v6 v6.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,3 +12,5 @@ github.com/gethinode/mod-utils/v5 v5.19.0 h1:fX3gTsYoimUNqD/KeBsyBrrJ2DygQ0M7Rc8
 github.com/gethinode/mod-utils/v5 v5.19.0/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
 github.com/gethinode/mod-utils/v6 v6.0.1 h1:EnmMHjqnI/xyHPXFj1SdRLfVxNunJcKLGVtSAAFTQ8w=
 github.com/gethinode/mod-utils/v6 v6.0.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
+github.com/gethinode/mod-utils/v6 v6.5.0 h1:NdeITAfjt2ah9OHt0Nuu6F+STlC0bO9oHaFl8Agi2rk=
+github.com/gethinode/mod-utils/v6 v6.5.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=

--- a/layouts/shortcodes/map.html
+++ b/layouts/shortcodes/map.html
@@ -22,7 +22,7 @@
 {{ end }}
 
 {{/* Initialize local arguments */}}
-{{- $id := $args.id | default (printf "leaflet-map-%d" .Ordinal) -}}
+{{- $id := $args.id | default (partial "utilities/UniqueID.html" (dict "prefix" "leaflet-map")) -}}
 
 {{/* Main code */}}
 {{- if not $error -}}


### PR DESCRIPTION
The `map` shortcode built its id from `.Ordinal`, which resets to 0 inside the `example` shortcode's embedded `RenderString`, so two maps in two `{{< example >}}` blocks collided on `leaflet-map-0`. It now uses mod-utils' `UniqueID` helper (`leaflet-map-UID-<n>`). The explicit `id` argument still overrides. Bumps the mod-utils pin to v6.5.0, which provides the helper.

Part of an ecosystem-wide `.Ordinal`→UniqueID migration; independent of the companion PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)