### PR TITLE
fix: register the leaflet module when the map shortcode renders

### DIFF
--- a/layouts/shortcodes/map.html
+++ b/layouts/shortcodes/map.html
@@ -26,6 +26,9 @@
 
 {{/* Main code */}}
 {{- if not $error -}}
+    {{/* Register the leaflet module as a page dependency, so the page's script and stylesheet
+         handlers include its assets without requiring `modules = ["leaflet"]` in front matter. */}}
+    {{- partial "utilities/AddModule.html" (dict "page" .Page "module" "leaflet") -}}
     {{/* The gesture hints are rendered here so they stay translatable. The modifier is left as
          a placeholder for the script, which resolves it to the visitor's platform. */}}
     <div id="{{ $id }}" class="leaflet-map {{ $args.class }}"


### PR DESCRIPTION
The `map` shortcode rendered its markup but shipped no leaflet JS/CSS unless the page author remembered front-matter `modules = ["leaflet"]`. The shortcode now self-registers via `utilities/AddModule.html` (mod-utils v6.5.0+, already imported).

Evidence (js-pipeline program J2): bare-shortcode page vs front-matter control on a hinode v3.6.2 exampleSite — before: no tags on the bare page; after: script+stylesheet tags byte-identical to the control, zero build errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)